### PR TITLE
Added option to add files as streams. 

### DIFF
--- a/client/src/main/java/com/phaxio/repositories/FaxRepository.java
+++ b/client/src/main/java/com/phaxio/repositories/FaxRepository.java
@@ -1,5 +1,6 @@
 package com.phaxio.repositories;
 
+import com.phaxio.resources.FileStream;
 import com.phaxio.services.Requests;
 import com.phaxio.resources.Fax;
 import com.phaxio.restclient.entities.RestRequest;
@@ -8,6 +9,7 @@ import org.apache.commons.io.IOUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +26,7 @@ public class FaxRepository {
      * Sends a fax
      * @param options A HashMap representing all the parameters for the fax. See the Phaxio documentation for the exact parameter names.
      *                Note that for fields that allow multiple items, use square brackets in the key and a Collection as the value.
+     *                Files can be added as File, file path or wrapped in new FileStream(inputStream, fileName).
      * @return The newly created Fax
      */
     public Fax create (Map<String, Object> options) {
@@ -42,11 +45,11 @@ public class FaxRepository {
                     request.addParameter(option.getKey(), url);
                 }
             } else if (option.getKey().equals("file")) {
-                addFile((File)option.getValue(), request);
+                addOneFile(option.getValue(), request, false);
             } else if (option.getKey().equals("file[]")) {
-                Collection<File> files = (Collection<File>)option.getValue();
-                for (File file : files) {
-                    addFile(file, request);
+                Collection files =(Collection) option.getValue();
+                for (Object file : files) {
+                    addOneFile(file, request, true);
                 }
             } else {
                 request.addParameter(option.getKey(), option.getValue());
@@ -118,18 +121,41 @@ public class FaxRepository {
         client.post(request);
     }
 
-    private void addFile (File file, RestRequest request) {
-        addFile(file, request, true);
+    private void addOneFile(Object fileObject, RestRequest request, boolean multiple) {
+        if (fileObject instanceof File) {
+            addFile((File) fileObject, request, multiple);
+        } else if (fileObject instanceof FileStream) {
+            addFile((FileStream) fileObject, request, multiple);
+        } else if (fileObject instanceof String) {
+            addFile(new File((String) fileObject), request, multiple);
+        } else {
+            throw new IllegalArgumentException("file must be File, file path or FileStream.");
+        }
     }
 
     private void addFile (File file, RestRequest request, boolean multiple) {
         String param = multiple ? "file[]" : "file";
 
         try {
-            byte[] bytes = IOUtils.toByteArray(new FileInputStream(file));
-            request.addFile(param, bytes, file.getName(), null);
+            FileInputStream input = new FileInputStream(file);
+            addFileParam(param, file.getName(), input, request);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void addFile(FileStream fileStream, RestRequest request, boolean multiple) {
+        String param = multiple ? "file[]" : "file";
+        try {
+            InputStream inputStream = fileStream.getInputStream();
+            addFileParam(param, fileStream.getFileName(), inputStream, request);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void addFileParam(String param, String file, InputStream input, RestRequest request) throws IOException {
+        byte[] bytes = IOUtils.toByteArray(input);
+        request.addFile(param, bytes, file, null);
     }
 }

--- a/client/src/main/java/com/phaxio/resources/FileStream.java
+++ b/client/src/main/java/com/phaxio/resources/FileStream.java
@@ -1,0 +1,24 @@
+package com.phaxio.resources;
+
+
+import java.io.InputStream;
+
+
+public class FileStream {
+  private final InputStream inputStream;
+
+  private final String fileName;
+
+  public FileStream(InputStream inputStream, String fileName) {
+    this.inputStream = inputStream;
+    this.fileName = fileName;
+  }
+
+  public InputStream getInputStream() {
+    return inputStream;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+}

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/FaxRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/FaxRepositoryTest.java
@@ -59,7 +59,7 @@ public class FaxRepositoryTest {
         verify(postRequestedFor(urlEqualTo("/v2/faxes"))
                 .withHeader("Content-Type", containing("multipart/form-data;"))
                 .withRequestBody(containing("test.pdf"))
-                .withRequestBody(containing("file[]"))
+                .withRequestBody(containing("file"))
                 .withRequestBody(containing("to"))
                 .withRequestBody(containing("2088675309"))
                 .withRequestBody(containing("content_url[]"))


### PR DESCRIPTION
Single stream marked multiple=false , as it was putting it as multiple=true.
Was not able to run tests locally before changes, but tested the solution against production, fax successfully sent.
This is very useful feature, when files shouldn't be downloaded to the disk due to the security requirements, enforcing upcoming GDPR guidelines in May 2017 in EU.