### PR TITLE
Allow unknown fields from Phaxio API service

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.phaxio</groupId>
     <artifactId>phaxio-java</artifactId>
-    <version>0.3.4</version>
+    <version>0.3.7</version>
 
     <name>Phaxio Java Client</name>
     <description>The official Phaxio client for the JVM</description>

--- a/client/src/main/java/com/phaxio/entities/Account.java
+++ b/client/src/main/java/com/phaxio/entities/Account.java
@@ -1,10 +1,12 @@
 package com.phaxio.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This represents a Phaxio account
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Account
 {
     @JsonProperty("balance")

--- a/client/src/main/java/com/phaxio/entities/AreaCode.java
+++ b/client/src/main/java/com/phaxio/entities/AreaCode.java
@@ -1,10 +1,12 @@
 package com.phaxio.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents the area codes where you can purchase numbers.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AreaCode
 {
     @JsonProperty("country_code")

--- a/client/src/main/java/com/phaxio/entities/Country.java
+++ b/client/src/main/java/com/phaxio/entities/Country.java
@@ -1,10 +1,12 @@
 package com.phaxio.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents the state of Phaxio support for a country.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Country
 {
     @JsonProperty("name")

--- a/client/src/main/java/com/phaxio/entities/Recipient.java
+++ b/client/src/main/java/com/phaxio/entities/Recipient.java
@@ -1,5 +1,6 @@
 package com.phaxio.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
@@ -7,6 +8,7 @@ import java.util.Date;
 /**
  * A fax recipient
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Recipient
 {
     @JsonProperty("phone_number")

--- a/client/src/main/java/com/phaxio/repositories/FaxRepository.java
+++ b/client/src/main/java/com/phaxio/repositories/FaxRepository.java
@@ -1,6 +1,6 @@
 package com.phaxio.repositories;
 
-import com.phaxio.resources.FileStream;
+import com.phaxio.restclient.entities.FileStream;
 import com.phaxio.services.Requests;
 import com.phaxio.resources.Fax;
 import com.phaxio.restclient.entities.RestRequest;

--- a/client/src/main/java/com/phaxio/resources/Fax.java
+++ b/client/src/main/java/com/phaxio/resources/Fax.java
@@ -1,5 +1,6 @@
 package com.phaxio.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.phaxio.services.Requests;
 import com.phaxio.entities.Recipient;
@@ -9,6 +10,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Fax
 {
     private Requests client;

--- a/client/src/main/java/com/phaxio/resources/PhaxCode.java
+++ b/client/src/main/java/com/phaxio/resources/PhaxCode.java
@@ -1,6 +1,7 @@
 package com.phaxio.resources;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.phaxio.services.Requests;
 import com.phaxio.restclient.RestClient;
@@ -11,6 +12,7 @@ import java.util.Date;
 /**
  * A PhaxCode is a barcode that Phaxio generates, which can be embedded with metadata.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PhaxCode
 {
     private Requests client;

--- a/client/src/main/java/com/phaxio/resources/PhoneNumber.java
+++ b/client/src/main/java/com/phaxio/resources/PhoneNumber.java
@@ -1,5 +1,6 @@
 package com.phaxio.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.phaxio.services.Requests;
 import com.phaxio.restclient.entities.RestRequest;
@@ -9,6 +10,7 @@ import java.util.Date;
 /**
  * A phone number that you can use to send faxes.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PhoneNumber
 {
     private Requests client;

--- a/client/src/main/java/com/phaxio/restclient/entities/FileStream.java
+++ b/client/src/main/java/com/phaxio/restclient/entities/FileStream.java
@@ -1,8 +1,6 @@
-package com.phaxio.resources;
-
+package com.phaxio.restclient.entities;
 
 import java.io.InputStream;
-
 
 public class FileStream {
   private final InputStream inputStream;

--- a/client/src/main/java/com/phaxio/services/Requests.java
+++ b/client/src/main/java/com/phaxio/services/Requests.java
@@ -3,7 +3,6 @@ package com.phaxio.services;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.phaxio.Phaxio;
 import com.phaxio.entities.Paging;
 import com.phaxio.exceptions.*;
 import com.phaxio.restclient.RestClient;
@@ -190,7 +189,7 @@ public class Requests {
     }
 
     private String getMessage(RestResponse response) throws IOException {
-        if (response.getContentType().equals("application/json")) {
+        if (response.getContentType().startsWith("application/json")) {
             return response.toJson().get("message").asText();
         } else {
             return "";

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/FaxRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/FaxRepositoryTest.java
@@ -5,7 +5,7 @@ import com.phaxio.Phaxio;
 import com.phaxio.entities.Recipient;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.Fax;
-import com.phaxio.resources.FileStream;
+import com.phaxio.restclient.entities.FileStream;
 import com.phaxio.services.Requests;
 import org.junit.Rule;
 import org.junit.Test;

--- a/client/src/test/java/com/phaxio/unittests/AccountTest.java
+++ b/client/src/test/java/com/phaxio/unittests/AccountTest.java
@@ -1,0 +1,25 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.Account;
+import com.phaxio.helpers.Responses;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AccountTest {
+    @Test
+    public void ignoresExtraFields () throws IOException {
+        String json = Responses.json("/jsonobjects/account_status_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Account account = mapper.readValue(json, Account.class);
+
+        assertEquals(5050, account.balance);
+        assertEquals(15, account.faxesThisMonth.sent);
+        assertEquals(7, account.faxesThisMonth.received);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/AreaCodeTests.java
+++ b/client/src/test/java/com/phaxio/unittests/AreaCodeTests.java
@@ -1,0 +1,29 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.AreaCode;
+import com.phaxio.helpers.Responses;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class AreaCodeTests {
+    @Test
+    public void ignoresExtraFields () throws IOException {
+        String json = Responses.json("/jsonobjects/area_code_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        AreaCode areaCode = mapper.readValue(json, AreaCode.class);
+
+        assertEquals("1", areaCode.countryCode);
+        assertEquals("203", areaCode.areaCode);
+        assertEquals("Bridgeport, Danbury, Meriden", areaCode.city);
+        assertEquals("Connecticut", areaCode.state);
+        assertEquals("United States", areaCode.country);
+        assertFalse(areaCode.tollFree);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/CountryTests.java
+++ b/client/src/test/java/com/phaxio/unittests/CountryTests.java
@@ -1,0 +1,28 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.Country;
+import com.phaxio.helpers.Responses;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class CountryTests {
+    @Test
+    public void ignoresExtraFields () throws IOException {
+        String json = Responses.json("/jsonobjects/country_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Country country = mapper.readValue(json, Country.class);
+
+        assertEquals("United States", country.name);
+        assertEquals("US", country.alpha2);
+        assertEquals("1", country.countryCode);
+        assertEquals(7, country.pricePerPage);
+        assertEquals("full", country.sendSupport);
+        assertEquals("fullest", country.receiveSupport);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/FaxTests.java
+++ b/client/src/test/java/com/phaxio/unittests/FaxTests.java
@@ -1,0 +1,60 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.Recipient;
+import com.phaxio.helpers.Responses;
+import com.phaxio.resources.Fax;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FaxTests {
+    @Test
+    public void ignoresExtraFields () throws IOException, ParseException {
+        String json = Responses.json("/jsonobjects/fax_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Fax fax = mapper.readValue(json, Fax.class);
+
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
+        Date createdAt = format.parse("2015-09-02T11:28:02-0500");
+        Date completedAt = format.parse("2015-09-02T11:28:54-0500");
+
+        assertEquals(123456, fax.id);
+        assertEquals("sent", fax.direction);
+        assertEquals(3, fax.pageCount);
+        assertEquals("success", fax.status);
+        assertTrue(fax.isTest);
+        assertEquals(createdAt, fax.createdAt);
+        assertEquals(completedAt, fax.completedAt);
+        assertEquals(21, fax.costInCents);
+        assertEquals("123", fax.fromNumber);
+        assertEquals("1234", fax.tags.get("order_id"));
+        assertEquals("321", fax.toNumber);
+        assertEquals("Caller", fax.callerId);
+        assertEquals(42, fax.errorId);
+        assertEquals("error_type", fax.errorType);
+        assertEquals("error_message", fax.errorMessage);
+
+        Recipient recipient = fax.recipients.get(0);
+
+        assertEquals("+14141234567", recipient.phoneNumber);
+        assertEquals(completedAt, recipient.completedAt);
+        assertEquals("success", recipient.status);
+        assertEquals(41, recipient.errorId);
+        assertEquals("recipient_error_type", recipient.errorType);
+        assertEquals("recipient_error_message", recipient.errorMessage);
+        assertEquals(3, recipient.retryCount);
+        assertEquals(14400, recipient.bitrate);
+        assertEquals(8040, recipient.resolution);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/PhaxCodeTests.java
+++ b/client/src/test/java/com/phaxio/unittests/PhaxCodeTests.java
@@ -1,0 +1,23 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.resources.PhaxCode;
+import com.phaxio.helpers.Responses;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhaxCodeTests {
+    @Test
+    public void ignoresExtraFields () throws IOException {
+        String json = Responses.json("/jsonobjects/phax_code_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        PhaxCode phaxCode = mapper.readValue(json, PhaxCode.class);
+
+        assertEquals("1234", phaxCode.identifier);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/PhoneNumberTests.java
+++ b/client/src/test/java/com/phaxio/unittests/PhoneNumberTests.java
@@ -1,0 +1,40 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.helpers.Responses;
+import com.phaxio.resources.PhoneNumber;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhoneNumberTests {
+    @Test
+    public void ignoresExtraFields () throws IOException, ParseException {
+        String json = Responses.json("/jsonobjects/phone_number_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        PhoneNumber number = mapper.readValue(json, PhoneNumber.class);
+
+        assertEquals("+18475551234", number.number);
+
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
+        Date lastBilledAt = format.parse("2016-05-10T11:38:15-0500");
+        Date provisionedAt = format.parse("2016-03-10T11:38:15-0600");
+
+        assertEquals("Northbrook", number.city);
+        assertEquals("Illinois", number.state);
+        assertEquals("United States", number.country);
+        assertEquals(200, number.cost);
+        assertEquals(lastBilledAt, number.lastBilled);
+        assertEquals(provisionedAt, number.provisioned);
+        assertEquals("http://example.com", number.callbackUrl);
+    }
+}

--- a/client/src/test/java/com/phaxio/unittests/RecipientTests.java
+++ b/client/src/test/java/com/phaxio/unittests/RecipientTests.java
@@ -1,0 +1,39 @@
+package com.phaxio.unittests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.Recipient;
+import com.phaxio.helpers.Responses;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class RecipientTests {
+    @Test
+    public void ignoresExtraFields () throws IOException, ParseException {
+        String json = Responses.json("/jsonobjects/recipient_extra_fields.json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Recipient recipient = mapper.readValue(json, Recipient.class);
+
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
+        Date completedAt = format.parse("2015-09-02T11:28:54-0500");
+
+        assertEquals("+14141234567", recipient.phoneNumber);
+        assertEquals(completedAt, recipient.completedAt);
+        assertEquals("success", recipient.status);
+        assertEquals(41, recipient.errorId);
+        assertEquals("recipient_error_type", recipient.errorType);
+        assertEquals("recipient_error_message", recipient.errorMessage);
+        assertEquals(3, recipient.retryCount);
+        assertEquals(14400, recipient.bitrate);
+        assertEquals(8040, recipient.resolution);
+    }
+}

--- a/client/src/test/resources/jsonobjects/account_status_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/account_status_extra_fields.json
@@ -1,0 +1,12 @@
+﻿{
+    "balance":5050,
+    "extra": "extra",
+    "faxes_today": {
+        "sent": 1,
+        "received": 2
+    },
+    "faxes_this_month": {
+        "sent": 15,
+        "received": 7
+    }
+}

--- a/client/src/test/resources/jsonobjects/area_code_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/area_code_extra_fields.json
@@ -1,0 +1,9 @@
+{
+  "country_code":1,
+  "area_code":203,
+  "extra": "extra",
+  "city":"Bridgeport, Danbury, Meriden",
+  "state":"Connecticut",
+  "country":"United States",
+  "toll_free":false
+}

--- a/client/src/test/resources/jsonobjects/country_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/country_extra_fields.json
@@ -1,0 +1,9 @@
+{
+  "name":"United States",
+  "alpha2":"US",
+  "country_code":1,
+  "price_per_page":7,
+  "send_support":"full",
+  "receive_support":"fullest",
+  "extra": "extra"
+}

--- a/client/src/test/resources/jsonobjects/fax_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/fax_extra_fields.json
@@ -1,0 +1,33 @@
+{
+  "id":123456,
+  "extra": "extra",
+  "direction":"sent",
+  "num_pages":3,
+  "status":"success",
+  "is_test":true,
+  "created_at":"2015-09-02T11:28:02.000-05:00",
+  "from_number":"123",
+  "completed_at":"2015-09-02T11:28:54.000-05:00",
+  "caller_id":"Caller",
+  "cost":21,
+  "tags":{
+    "order_id":"1234"
+  },
+  "recipients":[
+    {
+      "phone_number":"+14141234567",
+      "status":"success",
+      "completed_at":"2015-09-02T11:28:54.000-05:00",
+      "error_type":"recipient_error_type",
+      "error_id": 41,
+      "error_message":"recipient_error_message",
+      "retry_count": 3,
+      "bitrate": 14400,
+      "resolution": 8040
+    }
+  ],
+  "to_number":"321",
+  "error_id":42,
+  "error_type":"error_type",
+  "error_message":"error_message"
+}

--- a/client/src/test/resources/jsonobjects/phax_code_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/phax_code_extra_fields.json
@@ -1,0 +1,6 @@
+{
+    "identifier": "1234",
+    "metadata": "some_stuff",
+    "created_at":"2015-09-02T11:28:02.000-05:00",
+    "extra": "extra"
+}

--- a/client/src/test/resources/jsonobjects/phone_number_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/phone_number_extra_fields.json
@@ -1,0 +1,10 @@
+{
+    "phone_number":"+18475551234",
+    "city":"Northbrook",
+    "state":"Illinois",
+    "country":"United States",
+    "cost":200,
+    "last_billed_at":"2016-05-10T11:38:15.000-05:00",
+    "provisioned_at":"2016-03-10T11:38:15.000-06:00",
+    "callback_url":"http://example.com"
+}

--- a/client/src/test/resources/jsonobjects/recipient_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/recipient_extra_fields.json
@@ -1,0 +1,12 @@
+{
+  "phone_number":"+14141234567",
+  "extra": "extra",
+  "status":"success",
+  "completed_at":"2015-09-02T11:28:54.000-05:00",
+  "error_type":"recipient_error_type",
+  "error_id": 41,
+  "error_message":"recipient_error_message",
+  "retry_count": 3,
+  "bitrate": 14400,
+  "resolution": 8040
+}


### PR DESCRIPTION
Before this PR, if the Phaxio API service returned a field in the JSON response that was previously unknown and unspecified, the client would return an error. This PR allows extra fields to be present and ignored.

This also introduces unit tests, and fixes a bug where error messages were not being returned due to an unexpected content type.