### PR TITLE
Update library to use Phaxio API to use v2.1

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.phaxio</groupId>
     <artifactId>phaxio-java</artifactId>
-    <version>0.3.8</version>
+    <version>0.4.0</version>
 
     <name>Phaxio Java Client</name>
     <description>The official Phaxio client for the JVM</description>
@@ -37,8 +37,8 @@
         <connection>scm:git:git@github.com:phaxio/phaxio-java.git</connection>
         <developerConnection>scm:git:git@github.com:phaxio/phaxio-java.git</developerConnection>
         <url>git@github.com:phaxio/phaxio-java.git</url>
-        <tag>phaxio-java-0.3.4</tag>
-  </scm>
+        <tag>phaxio-java-0.4.0</tag>
+    </scm>
 
     <dependencies>
         <dependency>

--- a/client/src/main/java/com/phaxio/Phaxio.java
+++ b/client/src/main/java/com/phaxio/Phaxio.java
@@ -10,23 +10,25 @@ import com.phaxio.services.Requests;
  * The Phaxio API client.
  */
 public class Phaxio {
-    private static final String PHAXIO_ENDPOINT = "https://api.phaxio.com:%s/v2/";
+    private static final String PHAXIO_SERVICE = "https://api.phaxio.com:%s";
+    private static final String PHAXIO_VERSION_SEGMENT = "/v2.1/";
+    private static final String PHAXIO_ENDPOINT = PHAXIO_SERVICE + PHAXIO_VERSION_SEGMENT;
     private static final int PHAXIO_PORT = 443;
 
     public Phaxio(String key, String secret) {
     	this(key, secret, PHAXIO_ENDPOINT, PHAXIO_PORT,null);
     }
     
-    public Phaxio(String key, String secret,Proxy proxy) {
-        this(key, secret, PHAXIO_ENDPOINT, PHAXIO_PORT,proxy);
+    public Phaxio(String key, String secret, Proxy proxy) {
+        this(key, secret, PHAXIO_ENDPOINT, PHAXIO_PORT, proxy);
     }
 
     public Phaxio(String key, String secret, String endpoint, int port) {
-    	this(key,secret,endpoint,port,null);
+    	this(key, secret, endpoint, port, null);
     }
     
-    private Phaxio(String key, String secret, String endpoint, int port,Proxy proxy) {
-        Requests requests = new Requests(key, secret, endpoint, port,proxy);
+    private Phaxio(String key, String secret, String endpoint, int port, Proxy proxy) {
+        Requests requests = new Requests(key, secret, endpoint, port, proxy);
 
         fax = new FaxRepository(requests);
         publicInfo = new PublicRepository(requests);

--- a/client/src/main/java/com/phaxio/entities/Barcode.java
+++ b/client/src/main/java/com/phaxio/entities/Barcode.java
@@ -1,0 +1,20 @@
+package com.phaxio.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Barcode {
+    @JsonProperty("type")
+    public String type;
+
+    @JsonProperty("page")
+    public int page;
+
+    @JsonProperty("value")
+    public String value;
+
+    @JsonProperty("identifier")
+    public String identifier;
+
+    @JsonProperty("metadata")
+    public String metadata;
+}

--- a/client/src/main/java/com/phaxio/resources/Fax.java
+++ b/client/src/main/java/com/phaxio/resources/Fax.java
@@ -3,6 +3,7 @@ package com.phaxio.resources;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.phaxio.services.Requests;
+import com.phaxio.entities.Barcode;
 import com.phaxio.entities.Recipient;
 import com.phaxio.restclient.entities.RestRequest;
 
@@ -40,9 +41,6 @@ public class Fax
     @JsonProperty("id")
     public int id;
 
-    @JsonProperty("direction")
-    public String direction;
-
     public int getId() {
         return id;
     }
@@ -50,6 +48,15 @@ public class Fax
     public void setId(int id) {
         this.id = id;
     }
+
+    @JsonProperty("direction")
+    public String direction;
+
+    @JsonProperty("barcodes")
+    public List<Barcode> barcodes;
+
+    @JsonProperty("caller_name")
+    public String callerName;
 
     @JsonProperty("num_pages")
     public int pageCount;

--- a/client/src/main/java/com/phaxio/restclient/BasicAuthorization.java
+++ b/client/src/main/java/com/phaxio/restclient/BasicAuthorization.java
@@ -1,10 +1,10 @@
 package com.phaxio.restclient;
 
-public class BasicAuthentication {
+public class BasicAuthorization {
     public final String username;
     public final String password;
 
-    public BasicAuthentication(String username, String password) {
+    public BasicAuthorization(String username, String password) {
         this.username = username;
         this.password = password;
     }

--- a/client/src/main/java/com/phaxio/restclient/RestClient.java
+++ b/client/src/main/java/com/phaxio/restclient/RestClient.java
@@ -13,15 +13,15 @@ import java.net.*;
 public class RestClient {
     private static final int TIMEOUT = 30000;
     private final String endpoint;
-    private BasicAuthentication auth;
+    private BasicAuthorization auth;
     final private  Proxy proxy;
     
-    public RestClient(String endpoint,Proxy proxy) {
+    public RestClient(String endpoint, Proxy proxy) {
         this.endpoint = endpoint;
         this.proxy = proxy;
     }
     
-    public void setAuthentication(BasicAuthentication auth) {
+    public void setAuthorization(BasicAuthorization auth) {
         this.auth = auth;
     }
 
@@ -101,7 +101,7 @@ public class RestClient {
                         dos.writeBytes("--\r\n");
                         dos.flush();
                         dos.close();
-                    } else {
+                    } else if (!request.parameters.isEmpty()) {
                         byte[] body = getQueryString(request).substring(1).getBytes("UTF-8");
 
                         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
@@ -113,6 +113,8 @@ public class RestClient {
                         dos.write(body);
                         dos.flush();
                         dos.close();
+                    } else {
+                        conn.setRequestProperty("Content-Length", "0");
                     }
 
                     break;

--- a/client/src/main/java/com/phaxio/services/Requests.java
+++ b/client/src/main/java/com/phaxio/services/Requests.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.phaxio.entities.Paging;
 import com.phaxio.exceptions.*;
+import com.phaxio.restclient.BasicAuthorization;
 import com.phaxio.restclient.RestClient;
 import com.phaxio.restclient.entities.Method;
 import com.phaxio.restclient.entities.RestRequest;
@@ -19,25 +20,17 @@ import java.net.Proxy;
 import java.util.*;
 
 public class Requests {
-
-    private static final String KEY_PARAMETER = "api_key";
-    private static final String SECRET_PARAMETER = "api_secret";
-
-    private final String key;
-    private final String secret;
     private final RestClient client;
 
     public Requests(String key, String secret, String endpoint, int port) {
-    	this(key,secret,endpoint,port,null);
+    	this(key, secret, endpoint, port, null);
     }
     
-    public Requests(String key, String secret, String endpoint, int port,Proxy proxy) {
-        this.secret = secret;
-        this.key = key;
-
+    public Requests(String key, String secret, String endpoint, int port, Proxy proxy) {
         String endpointWithPort = String.format(endpoint, port);
 
-        client = new RestClient(endpointWithPort,proxy);
+        client = new RestClient(endpointWithPort, proxy);
+        client.setAuthorization(new BasicAuthorization(key, secret));
     }
 
     public <T> T get(RestRequest request, Class clazz) {
@@ -161,9 +154,6 @@ public class Requests {
     }
 
     private RestResponse execute(RestRequest request) {
-        request.addOrReplaceParameter(SECRET_PARAMETER, secret);
-        request.addOrReplaceParameter(KEY_PARAMETER, key);
-
         RestResponse response = client.execute(request);
 
         // Check connection errors

--- a/client/src/test/java/com/phaxio/helpers/Auth.java
+++ b/client/src/test/java/com/phaxio/helpers/Auth.java
@@ -1,0 +1,16 @@
+package com.phaxio.helpers;
+
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.phaxio.restclient.BasicAuthorization;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+
+public class Auth {
+    public static final String VALID_KEY = "KEY";
+    public static final String VALID_SECRET = "SECRET";
+    public static final StringValuePattern VALID_AUTH_MATCHER = equalTo(new BasicAuthorization(VALID_KEY, VALID_SECRET).toHeader());
+
+    public static StringValuePattern authMatcher(String username, String password) {
+        return equalTo(new BasicAuthorization(username, password).toHeader());
+    }
+}

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/AccountRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/AccountRepositoryTest.java
@@ -3,6 +3,7 @@ package com.phaxio.integrationtests.mocked;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.entities.Account;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,13 +23,14 @@ public class AccountRepositoryTest {
     public void getsAccountStatus () throws IOException {
         String json = Responses.json("/account_status.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Account account = phaxio.account.status();
 

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/AreaCodeRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/AreaCodeRepositoryTest.java
@@ -3,6 +3,7 @@ package com.phaxio.integrationtests.mocked;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.entities.AreaCode;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,13 +26,14 @@ public class AreaCodeRepositoryTest {
     public void listsAreaCodes () throws IOException {
         String json = Responses.json("/list_area_codes.json");
 
-        stubFor(get(urlEqualTo("/v2/public/area_codes?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/public/area_codes"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Iterable<AreaCode> codes = phaxio.publicInfo.areaCode.list();
 

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/FaxFileTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/FaxFileTest.java
@@ -3,6 +3,7 @@ package com.phaxio.integrationtests.mocked;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.fixtures.BinaryFixtures;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.FaxFile;
 import com.phaxio.services.Requests;
@@ -24,13 +25,14 @@ public class FaxFileTest {
     public void getsFaxFile () throws IOException {
         byte[] fileBytes = Responses.file("/test.pdf");
 
-        stubFor(get(urlEqualTo("/v2/faxes/1/file?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/faxes/1/file"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/pdf")
                         .withBody(fileBytes)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         FaxFile file = new FaxFile(1);
 
@@ -43,13 +45,14 @@ public class FaxFileTest {
     public void getsLargeThumbnail () throws IOException {
         byte[] fileBytes = BinaryFixtures.getTestPhaxCode();
 
-        stubFor(get(urlEqualTo("/v2/faxes/1/file?thumbnail=l&api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/faxes/1/file?thumbnail=l"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/octet")
                         .withBody(fileBytes)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         FaxFile file = new FaxFile(1);
 
@@ -62,13 +65,14 @@ public class FaxFileTest {
     public void getsSmallThumbnail () throws IOException {
         byte[] fileBytes = BinaryFixtures.getTestPhaxCode();
 
-        stubFor(get(urlEqualTo("/v2/faxes/1/file?thumbnail=s&api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/faxes/1/file?thumbnail=s"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/octet")
                         .withBody(fileBytes)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         FaxFile file = new FaxFile(1);
 
@@ -81,18 +85,20 @@ public class FaxFileTest {
     public void deletesFax () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(delete(urlEqualTo("/v2/faxes/1/file?api_secret=SECRET&api_key=KEY"))
+        stubFor(delete(urlEqualTo("/ver/faxes/1/file"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         FaxFile file = new FaxFile(1);
         file.setClient(client);
         file.delete();
 
-        verify(deleteRequestedFor(urlEqualTo("/v2/faxes/1/file?api_secret=SECRET&api_key=KEY")));
+        verify(deleteRequestedFor(urlEqualTo("/ver/faxes/1/file"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER));
     }
 }

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/FaxTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/FaxTest.java
@@ -2,6 +2,7 @@ package com.phaxio.integrationtests.mocked;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
+ import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.Fax;
 import com.phaxio.services.Requests;
@@ -22,13 +23,14 @@ public class FaxTest {
     public void deletesFax () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(delete(urlEqualTo("/v2/faxes/1?api_secret=SECRET&api_key=KEY"))
+        stubFor(delete(urlEqualTo("/ver/faxes/1"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Fax fax = new Fax();
         fax.id = 1;
@@ -36,20 +38,21 @@ public class FaxTest {
 
         fax.delete();
 
-        verify(deleteRequestedFor(urlEqualTo("/v2/faxes/1?api_secret=SECRET&api_key=KEY")));
+        verify(deleteRequestedFor(urlEqualTo("/ver/faxes/1"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER));
     }
 
     @Test
     public void cancelsFax () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(post(urlEqualTo("/v2/faxes/1/cancel"))
+        stubFor(post(urlEqualTo("/ver/faxes/1/cancel"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Fax fax = new Fax();
         fax.id = 1;
@@ -57,20 +60,20 @@ public class FaxTest {
 
         fax.cancel();
 
-        verify(postRequestedFor(urlEqualTo("/v2/faxes/1/cancel")));
+        verify(postRequestedFor(urlEqualTo("/ver/faxes/1/cancel")));
     }
 
     @Test
     public void resendsFax () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(post(urlEqualTo("/v2/faxes/1/resend"))
+        stubFor(post(urlEqualTo("/ver/faxes/1/resend"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Fax fax = new Fax();
         fax.id = 1;
@@ -78,20 +81,20 @@ public class FaxTest {
 
         fax.resend();
 
-        verify(postRequestedFor(urlEqualTo("/v2/faxes/1/resend")));
+        verify(postRequestedFor(urlEqualTo("/ver/faxes/1/resend")));
     }
 
     @Test
     public void resendsFaxWithCallback () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(post(urlEqualTo("/v2/faxes/1/resend"))
+        stubFor(post(urlEqualTo("/ver/faxes/1/resend"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Fax fax = new Fax();
         fax.id = 1;
@@ -99,7 +102,7 @@ public class FaxTest {
 
         fax.resend("google.com");
 
-        verify(postRequestedFor(urlEqualTo("/v2/faxes/1/resend"))
+        verify(postRequestedFor(urlEqualTo("/ver/faxes/1/resend"))
                 .withRequestBody(containing("google.com")));
     }
 }

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxCodeRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxCodeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.phaxio.integrationtests.mocked;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
+import com.phaxio.helpers.Auth;
 import com.phaxio.resources.PhaxCode;
 import com.phaxio.helpers.Responses;
 import org.junit.Rule;
@@ -26,13 +27,13 @@ public class PhaxCodeRepositoryTest {
     public void createPhaxCode () throws IOException {
         String json = Responses.json("/phax_code.json");
 
-        stubFor(post(urlEqualTo("/v2/phax_codes.json"))
+        stubFor(post(urlEqualTo("/ver/phax_codes.json"))
                 .willReturn(aResponse()
                         .withStatus(201)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhaxCode code = phaxio.phaxCode.create("1234");
 
@@ -43,13 +44,14 @@ public class PhaxCodeRepositoryTest {
     public void retrieveDefaultPhaxCode () throws IOException, ParseException {
         String json = Responses.json("/phax_code.json");
 
-        stubFor(get(urlEqualTo("/v2/phax_code.json?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phax_code.json"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhaxCode code = phaxio.phaxCode.retrieve();
 
@@ -67,13 +69,14 @@ public class PhaxCodeRepositoryTest {
     public void retrievePhaxCode () throws IOException {
         String json = Responses.json("/phax_code.json");
 
-        stubFor(get(urlEqualTo("/v2/phax_codes/1234.json?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phax_codes/1234.json"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhaxCode code = phaxio.phaxCode.retrieve("1234");
 

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxCodeTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxCodeTest.java
@@ -3,6 +3,7 @@ package com.phaxio.integrationtests.mocked;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.fixtures.BinaryFixtures;
+import com.phaxio.helpers.Auth;
 import com.phaxio.resources.PhaxCode;
 import com.phaxio.services.Requests;
 import org.junit.Rule;
@@ -23,13 +24,14 @@ public class PhaxCodeTest {
     public void retrievePhaxCodePng () throws IOException {
         byte[] expectedBytes = BinaryFixtures.getTestPhaxCode();
 
-        stubFor(get(urlEqualTo("/v2/phax_codes/1234.png?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phax_codes/1234.png"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/octet")
                         .withBody(expectedBytes)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhaxCode code = new PhaxCode();
 
@@ -45,13 +47,14 @@ public class PhaxCodeTest {
     public void retrieveDefaultPhaxCodePng () throws IOException {
         byte[] expectedBytes = BinaryFixtures.getTestPhaxCode();
 
-        stubFor(get(urlEqualTo("/v2/phax_code.png?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phax_code.png"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/octet")
                         .withBody(expectedBytes)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhaxCode code = new PhaxCode();
 

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxioTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/PhaxioTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.entities.Country;
 import com.phaxio.exceptions.*;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import com.phaxio.restclient.entities.RestRequest;
 import com.phaxio.services.Requests;
@@ -24,22 +25,25 @@ public class PhaxioTest {
 
     @Test(expected = AuthenticationException.class)
     public void throwsExceptionOnInvalidCredentials () {
+        String badKey = "BAD_KEY";
+        String badSecret = "BAD_SECRET";
         String error = Responses.json("/error_authentication.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=BAD_SECRET&api_key=BAD_KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.authMatcher(badKey, badSecret))
                 .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(error)));
 
-        Phaxio phaxio = new Phaxio("BAD_KEY", "BAD_SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(badKey, badSecret, "http://localhost:%s/ver/", TEST_PORT);
 
         phaxio.account.status();
     }
 
     @Test(expected = ApiConnectionException.class)
     public void throwsApiExceptionWhenCannotConnect () {
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://not_real:%s/v2/", 80);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://not_real:%s/ver/", 80);
 
         phaxio.account.status();
     }
@@ -48,14 +52,15 @@ public class PhaxioTest {
     public void throwsInvalidRequestExceptionOnBadRequest () {
         String error = Responses.json("/error_invalid_entity.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(422)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(error)));
 
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         phaxio.account.status();
     }
@@ -64,14 +69,15 @@ public class PhaxioTest {
     public void throwsNotFoundExceptionOn404 () {
         String error = Responses.json("/error_not_found.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(404)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(error)));
 
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         phaxio.account.status();
     }
@@ -80,14 +86,15 @@ public class PhaxioTest {
     public void throwsRateLimitExceptionOn429 () {
         String error = Responses.json("/error_rate_limited.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(429)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(error)));
 
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         phaxio.account.status();
     }
@@ -96,14 +103,15 @@ public class PhaxioTest {
     public void throwsServerExceptionOn500 () {
         String error = Responses.json("/error_service.json");
 
-        stubFor(get(urlEqualTo("/v2/account/status?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/account/status"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(500)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(error)));
 
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         phaxio.account.status();
     }
@@ -113,21 +121,23 @@ public class PhaxioTest {
         String page1 = Responses.json("/paging_page_1.json");
         String page2 = Responses.json("/paging_page_2.json");
 
-        stubFor(get(urlEqualTo("/v2/public/countries?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/public/countries"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(page1)));
 
 
-        stubFor(get(urlEqualTo("/v2/public/countries?api_secret=SECRET&api_key=KEY&page=2"))
+        stubFor(get(urlEqualTo("/ver/public/countries?page=2"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(page2)));
 
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         RestRequest request = new RestRequest();
         request.resource = "public/countries";

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/PhoneNumberRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/PhoneNumberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.phaxio.integrationtests.mocked;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.PhoneNumber;
 import org.junit.Rule;
@@ -28,13 +29,13 @@ public class PhoneNumberRepositoryTest {
     public void createsNumber () throws IOException, ParseException {
         String json = Responses.json("/provision_number.json");
 
-        stubFor(post(urlEqualTo("/v2/phone_numbers"))
+        stubFor(post(urlEqualTo("/ver/phone_numbers"))
                 .willReturn(aResponse()
                         .withStatus(201)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhoneNumber number = phaxio.phoneNumber.create("1", "808");
 
@@ -58,13 +59,14 @@ public class PhoneNumberRepositoryTest {
     public void retrievesNumber () throws IOException {
         String json = Responses.json("/retrieve_number.json");
 
-        stubFor(get(urlEqualTo("/v2/phone_numbers/18475551234?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phone_numbers/18475551234"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(201)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhoneNumber number = phaxio.phoneNumber.retrieve("18475551234");
 
@@ -75,13 +77,14 @@ public class PhoneNumberRepositoryTest {
     public void listsNumber () throws IOException {
         String json = Responses.json("/list_numbers.json");
 
-        stubFor(get(urlEqualTo("/v2/phone_numbers?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/phone_numbers"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(201)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Iterable<PhoneNumber> numbers = phaxio.phoneNumber.list();
 

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/PhoneNumberTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/PhoneNumberTest.java
@@ -1,6 +1,7 @@
 package com.phaxio.integrationtests.mocked;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.PhoneNumber;
 import com.phaxio.services.Requests;
@@ -21,13 +22,14 @@ public class PhoneNumberTest {
     public void deletesFax () throws IOException {
         String json = Responses.json("/generic_success.json");
 
-        stubFor(delete(urlEqualTo("/v2/phone_numbers/8088675308?api_secret=SECRET&api_key=KEY"))
+        stubFor(delete(urlEqualTo("/ver/phone_numbers/8088675308"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Requests client = new Requests("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Requests client = new Requests(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         PhoneNumber number = new PhoneNumber();
         number.number = "8088675308";
@@ -35,6 +37,7 @@ public class PhoneNumberTest {
 
         number.release();
 
-        verify(deleteRequestedFor(urlEqualTo("/v2/phone_numbers/8088675308?api_secret=SECRET&api_key=KEY")));
+        verify(deleteRequestedFor(urlEqualTo("/ver/phone_numbers/8088675308"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER));
     }
 }

--- a/client/src/test/java/com/phaxio/integrationtests/mocked/SupportedCountriesRepositoryTest.java
+++ b/client/src/test/java/com/phaxio/integrationtests/mocked/SupportedCountriesRepositoryTest.java
@@ -3,6 +3,7 @@ package com.phaxio.integrationtests.mocked;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.phaxio.Phaxio;
 import com.phaxio.entities.Country;
+import com.phaxio.helpers.Auth;
 import com.phaxio.helpers.Responses;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,13 +25,14 @@ public class SupportedCountriesRepositoryTest {
     public void listsCountries () throws IOException {
         String json = Responses.json("/supported_countries.json");
 
-        stubFor(get(urlEqualTo("/v2/public/countries?api_secret=SECRET&api_key=KEY"))
+        stubFor(get(urlEqualTo("/ver/public/countries"))
+                .withHeader("Authorization", Auth.VALID_AUTH_MATCHER)
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(json)));
 
-        Phaxio phaxio = new Phaxio("KEY", "SECRET", "http://localhost:%s/v2/", TEST_PORT);
+        Phaxio phaxio = new Phaxio(Auth.VALID_KEY, Auth.VALID_SECRET, "http://localhost:%s/ver/", TEST_PORT);
 
         Iterable<Country> countries = phaxio.publicInfo.supportedCountry.list();
 

--- a/client/src/test/java/com/phaxio/unittests/FaxTests.java
+++ b/client/src/test/java/com/phaxio/unittests/FaxTests.java
@@ -1,6 +1,7 @@
 package com.phaxio.unittests;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phaxio.entities.Barcode;
 import com.phaxio.entities.Recipient;
 import com.phaxio.helpers.Responses;
 import com.phaxio.resources.Fax;
@@ -12,6 +13,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -30,6 +32,15 @@ public class FaxTests {
         Date completedAt = format.parse("2015-09-02T11:28:54-0500");
 
         assertEquals(123456, fax.id);
+        assertEquals("Alice", fax.callerName);
+
+        Barcode barcode = fax.barcodes.get(0);
+        assertEquals("barcode-type-1", barcode.type);
+        assertEquals(1, barcode.page);
+        assertEquals("barcode-value-1", barcode.value);
+        assertEquals("phax-code-id-1", barcode.identifier);
+        assertEquals("phax-code-metadata-1", barcode.metadata);
+
         assertEquals("sent", fax.direction);
         assertEquals(3, fax.pageCount);
         assertEquals("success", fax.status);

--- a/client/src/test/resources/fax_info.json
+++ b/client/src/test/resources/fax_info.json
@@ -3,6 +3,14 @@
     "message":"Metadata for fax",
     "data":{
         "id":123456,
+        "barcodes":[{
+            "type": "barcode-type-1",
+            "page": 1,
+            "value" : "barcode-value-1",
+            "identifier": "phax-code-id-1",
+            "metadata": "phax-code-metadata-1"
+        }],
+        "caller_name": "Alice",
         "direction":"sent",
         "num_pages":3,
         "status":"success",

--- a/client/src/test/resources/fax_list.json
+++ b/client/src/test/resources/fax_list.json
@@ -4,6 +4,8 @@
     "data":[
         {
             "id":123456,
+            "barcodes":[],
+            "caller_name": "Alice",
             "direction":"sent",
             "num_pages":1,
             "status":"success",
@@ -32,6 +34,8 @@
         },
         {
             "id":123455,
+            "barcodes":[],
+            "caller_name": "Bob",
             "direction":"sent",
             "num_pages":1,
             "status":"success",
@@ -60,6 +64,8 @@
         },
         {
             "id":123454,
+            "barcodes":[],
+            "caller_name": "Cathy",
             "direction":"sent",
             "num_pages":1,
             "status":"success",

--- a/client/src/test/resources/jsonobjects/fax_extra_fields.json
+++ b/client/src/test/resources/jsonobjects/fax_extra_fields.json
@@ -1,6 +1,14 @@
 {
   "id":123456,
   "extra": "extra",
+  "barcodes": [{
+    "type": "barcode-type-1",
+    "page": 1,
+    "value" : "barcode-value-1",
+    "identifier": "phax-code-id-1",
+    "metadata": "phax-code-metadata-1"
+  }],
+  "caller_name": "Alice",
   "direction":"sent",
   "num_pages":3,
   "status":"success",

--- a/example/src/main/java/com/phaxio/example/entities/Barcode.java
+++ b/example/src/main/java/com/phaxio/example/entities/Barcode.java
@@ -1,0 +1,20 @@
+package com.phaxio.example.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Barcode {
+    @JsonProperty("type")
+    public String type;
+
+    @JsonProperty("page")
+    public int page;
+
+    @JsonProperty("value")
+    public String value;
+
+    @JsonProperty("identifier")
+    public String identifier;
+
+    @JsonProperty("metadata")
+    public String metadata;
+}

--- a/example/src/main/java/com/phaxio/example/entities/Fax.java
+++ b/example/src/main/java/com/phaxio/example/entities/Fax.java
@@ -11,6 +11,12 @@ public class Fax
     @JsonProperty("id")
     public int id;
 
+    @JsonProperty("caller_name")
+    public String callerName;
+
+    @JsonProperty("barcodes")
+    public List<Barcode> barcodes;
+
     @JsonProperty("direction")
     public String direction;
 

--- a/example/src/main/java/com/phaxio/example/resources/Callbacks.java
+++ b/example/src/main/java/com/phaxio/example/resources/Callbacks.java
@@ -9,7 +9,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.InputStream;
 
 @Path("callbacks")
@@ -19,11 +18,8 @@ public class Callbacks {
     @Consumes({MediaType.MULTIPART_FORM_DATA})
     @Produces(MediaType.APPLICATION_JSON)
     public Fax receive(@FormDataParam("filename") InputStream fileInputStream,
-                            @FormDataParam("filename") FormDataContentDisposition disposition,
-                            @FormDataParam("success") boolean success,
-                            @FormDataParam("is_test") boolean isTest,
-                            @FormDataParam("direction") String direction,
-                            @FormDataParam("fax") Fax fax) throws Exception {
+                       @FormDataParam("filename") FormDataContentDisposition disposition,
+                       @FormDataParam("fax") Fax fax) throws Exception {
 
         System.out.println("Id: " + fax.id);
 

--- a/example/src/test/java/com/phaxio/CallbackResourceTests.java
+++ b/example/src/test/java/com/phaxio/CallbackResourceTests.java
@@ -35,9 +35,6 @@ public class CallbackResourceTests {
 
         MultiPart multipartEntity = new FormDataMultiPart()
                 .field("fax", faxJson, MediaType.APPLICATION_JSON_TYPE)
-                .field("success", "true", MediaType.TEXT_PLAIN_TYPE)
-                .field("is_test", "false", MediaType.TEXT_PLAIN_TYPE)
-                .field("direction", "received", MediaType.TEXT_PLAIN_TYPE)
                 .bodyPart(filePart);
 
         Response response = target.request().post(


### PR DESCRIPTION
Phaxio has released a new API, so we need to update this client library to support those changes. There are three major updates: a new endpoint, removing parameters from the fax callback, and moving to HTTP Basic Authorization.

1) We're going to use a new endpoint for the library (a different version string). Only the tests needed to be rewritten for this change besides changing the String in the Phaxio class.

2) The callback example project needed to remove `success`, `is_test`, and `direction` from the expected parameters.

3) We needed to move to HTTP Basic Authorization. The RestClient accommodated this change, but called it Authentication, so I renamed the classes/methods from using the word authentication to authorization, and then changed the Phaxio class to use basic auth on the RestClient. This necessitated a bunch of changes to the tests that mocked the HTTP endpoints which is the majority of the lines in this commit.

Finally, a couple of minor changes: a previous PR didn't space parameters in method signatures and calls, so there are a few lines that just adding spaces. Secondly, barcodes (an array of ints) and callerName (a String) were added the Fax objects in the client and the example project.

Closes #22 