### PR TITLE
Update Jackson dependencies to 2.9.7 due to exploits in example

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -57,17 +57,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
The example project still used old Jackson dependencies.