### PR TITLE
Updating for Android compatibility

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.phaxio</groupId>
     <artifactId>phaxio-java</artifactId>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
 
     <name>Phaxio Java Client</name>
     <description>The official Phaxio client for the JVM</description>
@@ -37,7 +37,7 @@
         <connection>scm:git:git@github.com:phaxio/phaxio-java.git</connection>
         <developerConnection>scm:git:git@github.com:phaxio/phaxio-java.git</developerConnection>
         <url>git@github.com:phaxio/phaxio-java.git</url>
-        <tag>phaxio-java-0.4.0</tag>
+        <tag>phaxio-java-0.4.4</tag>
     </scm>
 
     <dependencies>
@@ -67,17 +67,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/client/src/main/java/com/phaxio/restclient/BasicAuthorization.java
+++ b/client/src/main/java/com/phaxio/restclient/BasicAuthorization.java
@@ -1,6 +1,7 @@
 package com.phaxio.restclient;
 
-import org.apache.commons.codec.binary.Base64;
+import java.io.UnsupportedEncodingException;
+import com.google.common.io.BaseEncoding;
 
 public class BasicAuthorization {
     public final String username;
@@ -13,6 +14,12 @@ public class BasicAuthorization {
 
     public String toHeader () {
         String authstring = username + ":" + password;
-        return "Basic " + Base64.encodeBase64String(authstring.getBytes());
+        String encodedString = "";
+
+        try {
+            encodedString = BaseEncoding.base64().encode(authstring.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException exception) { }
+
+        return "Basic " + encodedString;
     }
 }

--- a/client/src/main/java/com/phaxio/services/Requests.java
+++ b/client/src/main/java/com/phaxio/services/Requests.java
@@ -10,7 +10,6 @@ import com.phaxio.restclient.RestClient;
 import com.phaxio.restclient.entities.Method;
 import com.phaxio.restclient.entities.RestRequest;
 import com.phaxio.restclient.entities.RestResponse;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -96,7 +95,7 @@ public class Requests {
 
                     @Override
                     public void remove() {
-                        throw new NotImplementedException();
+                        throw new UnsupportedOperationException();
                     }
 
                     private Iterator<T> getIter () {

--- a/client/src/test/java/com/phaxio/integrationtests/scenarios/FaxRepositoryScenario.java
+++ b/client/src/test/java/com/phaxio/integrationtests/scenarios/FaxRepositoryScenario.java
@@ -86,7 +86,7 @@ public class FaxRepositoryScenario extends RateLimitedScenario {
         File testFile = new File(testFileUrl.getFile());
 
         options.put("file", testFile);
-        options.put("to", "2088675309");
+        options.put("to_number", "2088675309");
 
         phaxio.fax.testReceiveCallback(options);
     }
@@ -106,7 +106,7 @@ public class FaxRepositoryScenario extends RateLimitedScenario {
 
         phaxio.fax.create(options);
 
-        Thread.sleep(1000);
+        Thread.sleep(3000);
 
         Iterable<Fax> faxes = phaxio.fax.list();
 
@@ -116,6 +116,6 @@ public class FaxRepositoryScenario extends RateLimitedScenario {
             faxList.add(fax);
         }
 
-        assertTrue(faxList.size() > 1);
+        assertTrue(faxList.size() > 0);
     }
 }


### PR DESCRIPTION
This upgrade deals with Android compatibility: not only are there different Java APIs available, the implementations are incompatible and have different behavior. Specifically, the HTTP connection must be read entirely before closing. Reading after a call to close causes an error, since on Android, there's a different implementation that doesn't expect you to read the connection after closing.